### PR TITLE
Simplify ReaperNightmareScytheCombo

### DIFF
--- a/XIVComboExpanded/Combos/RPR.cs
+++ b/XIVComboExpanded/Combos/RPR.cs
@@ -157,7 +157,7 @@ namespace XIVComboExpandedestPlugin.Combos
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if ((actionID == RPR.SpinningScythe && !IsEnabled(CustomComboPreset.ReaperNightmareScytheCombo)) || (actionID == RPR.NightmareScythe && IsEnabled(CustomComboPreset.ReaperNightmareScytheCombo)))
+            if (actionID == (IsEnabled(CustomComboPreset.ReaperNightmareScytheCombo) ? RPR.NightmareScythe : RPR.SpinningScythe))
             {
                 var gauge = GetJobGauge<RPRGauge>();
 

--- a/XIVComboExpanded/Combos/RPR.cs
+++ b/XIVComboExpanded/Combos/RPR.cs
@@ -109,7 +109,7 @@ namespace XIVComboExpandedestPlugin.Combos
 
         protected override uint Invoke(uint actionID, uint lastComboMove, float comboTime, byte level)
         {
-            if ((actionID == RPR.Slice && !IsEnabled(CustomComboPreset.ReaperInfernalSliceCombo)) || (actionID == RPR.InfernalSlice && IsEnabled(CustomComboPreset.ReaperInfernalSliceCombo)))
+            if (actionID == (IsEnabled(CustomComboPreset.ReaperInfernalSliceCombo) ? RPR.InfernalSlice : RPR.Slice))
             {
                 var gauge = GetJobGauge<RPRGauge>();
 


### PR DESCRIPTION
Hi, long time no see!

I'm just here to suggest a very simple refactor. When you have a setting that changes `A == 1` or `A == 2`, you were doing:

`(A == 1 && !check2) || (A == 2 && check2)`

but if you like ternary operators, there's a cool trick you can do to simplify it:

`A == (check2 ? 2 : 1)`

The PR diff contains an example, but this also applies to this king of setting for all the combos.